### PR TITLE
allow whitespace in path by enclosing argument in ""

### DIFF
--- a/lua/texlabconfig/cmd.lua
+++ b/lua/texlabconfig/cmd.lua
@@ -6,11 +6,11 @@ local cache = require('texlabconfig.cache')
 local M = {}
 
 function M:str_inverse_search_cmd(str)
-    -- TODO:
-    -- check what happens when /path/to/file contains spaces
-    local tbl = utils.split(str)
-    if #tbl == 2 then
-        self:inverse_search_cmd(unpack(tbl))
+    -- match path and line number arguments in string
+    -- this allows for arguments to be enclosed in single or double quotes
+    local _, path, _, line = str:match([[(["']?)(.+)%1 (["']?)(%d+)%3]])
+    if path ~= "" and line ~= "" then
+        self:inverse_search_cmd(path, tonumber(line))
     end
 end
 


### PR DESCRIPTION
I changed the logic to extract path and line number from the argument string. This allows enclosing the arguments in single or double quotes, which allows whitespace in the path.

Because lua pattern matching is pretty limited, this does not allow escaped quotes inside of the quotes (but then one could use the other type of quotes).