### PR TITLE
Allow passing server to nvim-texlabconfig

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 )
 
 const (
+	defaultServer = ""
 	defaultFile = ""
 	defaultLine = 0
 )
@@ -28,13 +29,14 @@ func main() {
 	// Required flags are: -file string, -line int.
 	// Optional flag is; -cache_root string
 	// No other argument is needed.
+	server := flag.String("server", defaultServer, "Server name [REQUIRED] ")
 	file := flag.String("file", defaultFile, "Absolute filename [REQUIRED]")
 	line := flag.Int("line", defaultLine, "Line number [REQUIRED] ")
 	cache_root := flag.String("cache_root", defaultCacheRoot, "Path to nvim-texlabconfig.json file")
 
 	flag.Parse()
 
-	if flag.NArg() > 0 || *file == defaultFile || *line == defaultLine {
+	if flag.NArg() > 0 || *server == defaultServer || *file == defaultFile || *line == defaultLine {
 		log.Fatal("Flags are required")
 	}
 
@@ -48,6 +50,25 @@ func main() {
 	if err := json.Unmarshal(content, &servers); err != nil {
 		log.Fatal("Error during Unmarshal(): ", err)
 	}
+
+    // Try passed server first
+	v, err := nvim.Dial(*server)
+	if err != nil {
+		log.Print("Error during Dial nvim: ", err)
+	} else {
+        defer v.Close()
+        var result bool
+        if err := v.ExecLua("return require('texlabconfig').fn:inverse_search(...)", &result, file, line); err != nil {
+            log.Print("Error during ExecLua: ", err)
+        } else if !result {
+            log.Print("Error during inverse_search")
+        } else {
+            log.Printf("Pipe: %s, File: %s, Line: %d", server, *file, *line)
+            return
+        }
+    }
+
+    log.Print("Specified server not found, trying servers from cache.")
 
 	// ExecLua function `require('texlabconfig').fn:inverse_search` in the first avaiable nvim instance.
 	for _, serverName := range servers.ServerNames {


### PR DESCRIPTION
Resolves #14 

Adds the `-server` argument to `nvim-texlabconfig` so that the inverse search opens the TeX file in the right NeoVim instance. Requires passing `im.api.nvim_get_vvar('servername')` in the PDF viewer arguments. For example:

```vim
local texargs = {
    '--synctex-editor-command',
    [[nvim-texlabconfig -server ]] .. vim.api.nvim_get_vvar('servername') .. [[ -file '%{input}' -line %{line}]],
    '--synctex-forward',
    '%l:1:%f',
    '%p',
}
```