### PR TITLE
build: add lazy build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@
         require('texlabconfig').setup(config)
     end,
     -- ft = { 'tex', 'bib' }, -- Lazy-load on filetype
+    build = 'go build'
+    -- build = 'go build -o ~/.bin/' if e.g. ~/.bin/ is in $PATH
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@
         require('texlabconfig').setup(config)
     end,
     -- ft = { 'tex', 'bib' }, -- Lazy-load on filetype
-    build = 'go build'
-    -- build = 'go build -o ~/.bin/' if e.g. ~/.bin/ is in $PATH
 }
 ```
 

--- a/build.lua
+++ b/build.lua
@@ -1,0 +1,6 @@
+os.execute(
+    string.format(
+        'go build -C %s/lazy/nvim-texlabconfig',
+        vim.fn.stdpath("data")
+    )
+)


### PR DESCRIPTION
One of the most painful PRs ever. You won't believe it but the default `PWD` was whichever path you were in while using `nvim`. Ridiculous.

Closes #20