### PR TITLE
updated calls to vim.validate to be compliant with Nvim 1.0

### DIFF
--- a/lua/texlabconfig/config.lua
+++ b/lua/texlabconfig/config.lua
@@ -20,15 +20,13 @@ M.options = {}
 
 function M.setup(user_config)
     M.options = vim.tbl_deep_extend('force', defaults, user_config)
-    vim.validate({
-        cache_activate = { M.options.cache_activate, 'boolean' },
-        cache_filetypes = { M.options.cache_filetypes, 'table' },
-        cache_root = { M.options.cache_root, 'string' },
-        reverse_search_start_cmd = { M.options.reverse_search_start_cmd, 'function' },
-        reverse_search_edit_cmd = { M.options.reverse_search_edit_cmd, 'function' },
-        reverse_search_end_cmd = { M.options.reverse_search_end_cmd, 'function' },
-        file_permission_mode = { M.options.file_permission_mode, 'number' },
-    })
+    vim.validate(cache_activate, M.options.cache_activate, 'boolean')
+    vim.validate(cache_filetypes, M.options.cache_filetypes, 'table')
+    vim.validate(cache_root, M.options.cache_root, 'string')
+    vim.validate(reverse_search_start_cmd, M.options.reverse_search_start_cmd, 'function')
+    vim.validate(reverse_search_edit_cmd, M.options.reverse_search_edit_cmd, 'function')
+    vim.validate(reverse_search_end_cmd, M.options.reverse_search_end_cmd, 'function')
+    vim.validate(file_permission_mode, M.options.file_permission_mode, 'number')
 end
 
 return M


### PR DESCRIPTION
Disclaimer: This is my first pull request, if I made a mistake in the process feel free to point it out.

**Issue:**
I started to receive warnings when running `:checkhealth`:
```
- WARNING vim.validate is deprecated. Feature will be removed in Nvim 1.0
  - ADVICE:
    - use vim.validate(name, value, validator, optional_or_msg) instead.
    - stack traceback:
        /home/uname/.local/share/nvim/lazy/nvim-texlabconfig/lua/texlabconfig/config.lua:23
        /home/uname/.local/share/nvim/lazy/nvim-texlabconfig/lua/texlabconfig/init.lua:9
        /home/uname/.config/nvim/lua/lazyConfig.lua:40
        /home/uname/.local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:376
        [C]:-1
        /home/uname/.local/share/nvim/lazy/lazy.nvim/lua/lazy/core/util.lua:135
        /home/uname/.local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:391
        /home/uname/.local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:358
        /home/uname/.local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:197
        /home/uname/.local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:539
        /home/uname/.local/share/nvim/lazy/lazy.nvim/lua/lazy/core/loader.lua:560
        [C]:-1
        /home/uname/.config/nvim/lua/pluginOptions.lua:3
        [C]:-1
        /home/uname/Documents/git_projects/dotfiles/nvim/init.lua:4
```

**Proposed solution**
The [documentation](https://neovim.io/doc/user/lua.html#vim.validate()) of Neovim proposes to switch to the only format that will be supported in the future. It is a very small change (see diff).

**Tests**
The warning has disappeared from the output of `:checkhealth`. I also verified that my setup still works.



